### PR TITLE
Separate options for the module type prefix in IDs (anchors) and file names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The following is a summary of changes in each `newdoc` release, which is also a Git tag by the same name in this repository.
 
+## v2.11.0
+
+* Separate options for the module type prefix in IDs (anchors) and file names.
+
 ## v2.10.6
 
 * A prettier confirmation prompt when overwriting a file.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.0.15"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf8832993da70a4c6d13c581f4463c2bdda27b9bf1c5498dc4365543abe6d6f"
+checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
 dependencies = [
  "atty",
  "bitflags",
@@ -141,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.13"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
+checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -430,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -489,18 +489,18 @@ checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "6df50b7a60a0ad48e1b42eb38373eac8ff785d619fb14db917b4e63d5439361f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "a714fd32ba1d66047ce7d53dabd809e9922d538f9047de13cc4cffca47b36205"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -526,9 +526,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "newdoc"
-version = "2.10.6"
+version = "2.11.0"
 dependencies = [
  "askama",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "newdoc"
-version = "2.10.6"
+version = "2.11.0"
 description = "Generate pre-populated module files formatted with AsciiDoc that are used in Red Hat and Fedora documentation."
 authors = ["Marek Suchánek <msuchane@redhat.com>"]
 license = "GPL-3.0-or-later"
 edition = "2021"
 # Check the Rust version using `cargo msrv verify`.
-rust-version = "1.59"
+rust-version = "1.60"
 documentation = "https://docs.rs/newdoc"
 readme = "README.md"
 repository = "https://github.com/mrksu/newdoc"

--- a/docs/using-newdoc.adoc
+++ b/docs/using-newdoc.adoc
@@ -280,7 +280,10 @@ $ newdoc --validate modules/con_proper-module.adoc
 
 * To generate the file without the example, placeholder content, add the `--no-examples` or `-E` option when creating documents.
 
-* To create the file without the module type prefix in the ID and the file name, add the `--no-prefixes` or `-P` option.
+* By default, the content type prefix appears in the generated file name and not in the ID (anchor). To change this behavior, use the following options:
++
+`--no-file-prefixes` or `-P`:: Disables the file-name prefix.
+`--anchor-prefixes` or `-A`:: Enables the ID (anchor) prefix.
 
 * To specify the directory where `newdoc` saves the generated file, add the `--target-dir=<directory>` or `-T <directory>` option.
 

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -78,12 +78,12 @@ pub struct Cli {
     pub no_examples: bool,
 
     /// Do not use module type prefixes (such as `proc_`) in file names
-    #[arg(short = 'P', long = "no-file-prefixes", alias = "no-prefixes")]
+    #[arg(short = 'P', long, alias = "no-prefixes")]
     pub no_file_prefixes: bool,
 
-    /// Add use module type prefixes (such as `proc_`) in IDs
-    #[arg(short = 'I', long = "id-prefixes")]
-    pub id_prefixes: bool,
+    /// Add use module type prefixes (such as `proc_`) in AsciiDoc anchors
+    #[arg(short = 'A', long)]
+    pub anchor_prefixes: bool,
 
     /// Save the generated files in this directory
     #[arg(short = 'T', long = "target-dir", value_name = "DIRECTORY")]

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -77,9 +77,13 @@ pub struct Cli {
     #[arg(short = 'E', long = "no-examples", alias = "expert-mode")]
     pub no_examples: bool,
 
-    /// Do not use module type prefixes (such as `proc_`) in IDs and file names
-    #[arg(short = 'P', long = "no-prefixes")]
-    pub no_prefixes: bool,
+    /// Do not use module type prefixes (such as `proc_`) in file names
+    #[arg(short = 'P', long = "no-file-prefixes", alias = "no-prefixes")]
+    pub no_file_prefixes: bool,
+
+    /// Add use module type prefixes (such as `proc_`) in IDs
+    #[arg(short = 'I', long = "id-prefixes")]
+    pub id_prefixes: bool,
 
     /// Save the generated files in this directory
     #[arg(short = 'T', long = "target-dir", value_name = "DIRECTORY")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ const REGEX_ERROR: &str = "Failed to construct a regular expression. Please repo
 pub struct Options {
     pub comments: bool,
     pub file_prefixes: bool,
-    pub id_prefixes: bool,
+    pub anchor_prefixes: bool,
     pub examples: bool,
     pub target_dir: PathBuf,
     pub verbosity: Verbosity,
@@ -85,7 +85,7 @@ impl Options {
             // the feature is disabled, so the option is set to false.
             comments: !cli.no_comments,
             file_prefixes: !cli.no_file_prefixes,
-            id_prefixes: cli.id_prefixes,
+            anchor_prefixes: cli.anchor_prefixes,
             examples: !cli.no_examples,
             // Set the target directory as specified or fall back on the current directory
             target_dir: cli.target_dir.clone().unwrap_or_else(|| PathBuf::from(".")),
@@ -99,7 +99,7 @@ impl Default for Options {
         Self {
             comments: true,
             file_prefixes: true,
-            id_prefixes: false,
+            anchor_prefixes: false,
             examples: true,
             target_dir: PathBuf::from("."),
             verbosity: Verbosity::Default,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,8 @@ const REGEX_ERROR: &str = "Failed to construct a regular expression. Please repo
 #[derive(Debug, Clone)]
 pub struct Options {
     pub comments: bool,
-    pub prefixes: bool,
+    pub file_prefixes: bool,
+    pub id_prefixes: bool,
     pub examples: bool,
     pub target_dir: PathBuf,
     pub verbosity: Verbosity,
@@ -83,7 +84,8 @@ impl Options {
             // on the command line. If the no-comments or no-prefixes option is passed,
             // the feature is disabled, so the option is set to false.
             comments: !cli.no_comments,
-            prefixes: !cli.no_prefixes,
+            file_prefixes: !cli.no_file_prefixes,
+            id_prefixes: cli.id_prefixes,
             examples: !cli.no_examples,
             // Set the target directory as specified or fall back on the current directory
             target_dir: cli.target_dir.clone().unwrap_or_else(|| PathBuf::from(".")),
@@ -96,7 +98,8 @@ impl Default for Options {
     fn default() -> Self {
         Self {
             comments: true,
-            prefixes: true,
+            file_prefixes: true,
+            id_prefixes: false,
             examples: true,
             target_dir: PathBuf::from("."),
             verbosity: Verbosity::Default,

--- a/src/module.rs
+++ b/src/module.rs
@@ -195,6 +195,29 @@ impl Input {
     ///
     /// The file name is based on the module ID,
     /// with an optional prefix and the `.adoc` extension.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use newdoc::{ContentType, Input, Options};
+    ///
+    /// let mod_type = ContentType::Concept;
+    /// let title = "Default file name configuration";
+    /// let options = Options::default();
+    /// let input = Input::new(mod_type, title, &options);
+    ///
+    /// assert_eq!("con_default-file-name-configuration.adoc", input.file_name());
+    ///
+    /// let mod_type = ContentType::Concept;
+    /// let title = "No prefix file name configuration";
+    /// let options = Options {
+    ///     file_prefixes: false,
+    ///     ..Default::default()
+    /// };
+    /// let input = Input::new(mod_type, title, &options);
+    ///
+    /// assert_eq!("no-prefix-file-name-configuration.adoc", input.file_name());
+    /// ```
     #[must_use]
     pub fn file_name(&self) -> String {
         // Add a prefix only if they're enabled.
@@ -214,6 +237,28 @@ impl Input {
     /// Prepare the AsciiDoc anchor or ID.
     ///
     /// The anchor is based on the module ID, with an optional prefix.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use newdoc::{ContentType, Input, Options};
+    ///
+    /// let mod_type = ContentType::Concept;
+    /// let title = "Default anchor configuration";
+    /// let options = Options::default();
+    /// let input = Input::new(mod_type, title, &options);
+    ///
+    /// assert_eq!("default-anchor-configuration", input.anchor());
+    ///
+    /// let mod_type = ContentType::Concept;
+    /// let title = "Prefix anchor configuration";
+    /// let options = Options {
+    ///     anchor_prefixes: true,
+    ///     ..Default::default()
+    /// };
+    /// let input = Input::new(mod_type, title, &options);
+    ///
+    /// assert_eq!("con_prefix-anchor-configuration", input.anchor());
     #[must_use]
     pub fn anchor(&self) -> String {
         // Add a prefix only if they're enabled.

--- a/src/module.rs
+++ b/src/module.rs
@@ -203,9 +203,11 @@ impl Input {
         self.id() + suffix
     }
 
+    /// If prefixes are enabled, pick the right file prefix.
+    /// If prefixes are disabled, use an empty string for the prefix.
     fn prefix(&self) -> &'static str {
         if self.options.prefixes {
-            // If prefixes are enabled, pick the right file prefix
+            
             match self.mod_type {
                 ContentType::Assembly => "assembly_",
                 ContentType::Concept => "con_",
@@ -214,7 +216,6 @@ impl Input {
                 ContentType::Snippet => "snip_",
             }
         } else {
-            // If prefixes are disabled, use an empty string for the prefix
             ""
         }
     }

--- a/src/templating.rs
+++ b/src/templating.rs
@@ -37,7 +37,7 @@ use crate::REGEX_ERROR;
 #[template(path = "assembly.adoc", escape = "none")]
 struct AssemblyTemplate<'a> {
     // The field name must match the variable name in the template
-    module_id: &'a str,
+    module_anchor: &'a str,
     module_title: &'a str,
     include_statements: &'a str,
     examples: bool,
@@ -46,7 +46,7 @@ struct AssemblyTemplate<'a> {
 #[derive(Template)]
 #[template(path = "concept.adoc", escape = "none")]
 struct ConceptTemplate<'a> {
-    module_id: &'a str,
+    module_anchor: &'a str,
     module_title: &'a str,
     examples: bool,
 }
@@ -54,7 +54,7 @@ struct ConceptTemplate<'a> {
 #[derive(Template)]
 #[template(path = "procedure.adoc", escape = "none")]
 struct ProcedureTemplate<'a> {
-    module_id: &'a str,
+    module_anchor: &'a str,
     module_title: &'a str,
     examples: bool,
 }
@@ -62,7 +62,7 @@ struct ProcedureTemplate<'a> {
 #[derive(Template)]
 #[template(path = "reference.adoc", escape = "none")]
 struct ReferenceTemplate<'a> {
-    module_id: &'a str,
+    module_anchor: &'a str,
     module_title: &'a str,
     examples: bool,
 }
@@ -101,26 +101,26 @@ impl Input {
     pub fn text(&self) -> String {
         let mut document = match self.mod_type {
             ContentType::Assembly => AssemblyTemplate {
-                module_id: &self.id(),
+                module_anchor: &self.anchor(),
                 module_title: &self.title,
                 include_statements: &self.includes_block(),
                 examples: self.options.examples,
             }
             .render(),
             ContentType::Concept => ConceptTemplate {
-                module_id: &self.id(),
+                module_anchor: &self.anchor(),
                 module_title: &self.title,
                 examples: self.options.examples,
             }
             .render(),
             ContentType::Procedure => ProcedureTemplate {
-                module_id: &self.id(),
+                module_anchor: &self.anchor(),
                 module_title: &self.title,
                 examples: self.options.examples,
             }
             .render(),
             ContentType::Reference => ReferenceTemplate {
-                module_id: &self.id(),
+                module_anchor: &self.anchor(),
                 module_title: &self.title,
                 examples: self.options.examples,
             }

--- a/src/templating.rs
+++ b/src/templating.rs
@@ -95,7 +95,7 @@ impl Input {
         }
     }
 
-    /// Perform string replacements in the modular template that matches the `ModuleType`.
+    /// Perform string replacements in the modular template that matches the `ContentType`.
     /// Return the template text with all replacements.
     #[must_use]
     pub fn text(&self) -> String {

--- a/templates/assembly.adoc
+++ b/templates/assembly.adoc
@@ -4,7 +4,7 @@ For more information about nesting assemblies, see: https://redhat-documentation
 See also the complementary step on the last line of this file.
 ////
 
-ifdef::context[:parent-context-of-{{module_id}}: {context}]
+ifdef::context[:parent-context-of-{{module_anchor}}: {context}]
 
 ////
 Base the file name and the ID on the assembly title. For example:
@@ -24,10 +24,10 @@ Add the following attribute before the module ID:
 :_content-type: ASSEMBLY
 
 ifndef::context[]
-[id="{{module_id}}"]
+[id="{{module_anchor}}"]
 endif::[]
 ifdef::context[]
-[id="{{module_id}}_{context}"]
+[id="{{module_anchor}}_{context}"]
 endif::[]
 = {{module_title}}
 ////
@@ -36,7 +36,7 @@ Be sure to include a line break between the title and the :context: variable and
 If the assembly covers a task, start the title with a verb in the gerund form, such as Creating or Configuring.
 ////
 
-:context: {{module_id}}
+:context: {{module_anchor}}
 
 ////
 The `context` attribute enables module reuse. Every module ID includes {context}, which ensures that the module has a unique ID so you can include it multiple times in the same guide.
@@ -87,5 +87,5 @@ Optional. Delete if not used.
 ////
 Restore the context to what it was before this assembly.
 ////
-ifdef::parent-context-of-{{module_id}}[:context: {parent-context-of-{{module_id}}}]
-ifndef::parent-context-of-{{module_id}}[:!context:]
+ifdef::parent-context-of-{{module_anchor}}[:context: {parent-context-of-{{module_anchor}}}]
+ifndef::parent-context-of-{{module_anchor}}[:!context:]

--- a/templates/concept.adoc
+++ b/templates/concept.adoc
@@ -19,7 +19,7 @@ The ID is an anchor that links to the module. Avoid changing it after the module
 The `context` attribute enables module reuse. Every module ID includes {context}, which ensures that the module has a unique ID so you can include it multiple times in the same guide.
 ////
 
-[id="{{module_id}}_{context}"]
+[id="{{module_anchor}}_{context}"]
 = {{module_title}}
 ////
 In the title of concept modules, include nouns or noun phrases that are used in the body text. This helps readers and search engines find the information quickly. Do not start the title of concept modules with a verb. See also _Wording of headings_ in _The IBM Style Guide_.

--- a/templates/procedure.adoc
+++ b/templates/procedure.adoc
@@ -13,7 +13,7 @@ Add the following attribute before the module ID:
 ////
 :_content-type: PROCEDURE
 
-[id="{{module_id}}_{context}"]
+[id="{{module_anchor}}_{context}"]
 = {{module_title}}
 ////
 Start the title of a procedure module with a gerund, such as Creating, Installing, or Deploying.

--- a/templates/reference.adoc
+++ b/templates/reference.adoc
@@ -17,7 +17,7 @@ Add the following attribute before the module ID:
 ////
 :_content-type: REFERENCE
 
-[id="{{module_id}}_{context}"]
+[id="{{module_anchor}}_{context}"]
 = {{module_title}}
 ////
 In the title of a reference module, include nouns that are used in the body text. For example, "Keyboard shortcuts for ___" or "Command options for ___." This helps readers and search engines find the information quickly.

--- a/tests/generated/assembly_testing-that-an-assembly-forms-properly.adoc
+++ b/tests/generated/assembly_testing-that-an-assembly-forms-properly.adoc
@@ -4,7 +4,7 @@ For more information about nesting assemblies, see: https://redhat-documentation
 See also the complementary step on the last line of this file.
 ////
 
-ifdef::context[:parent-context-of-assembly_testing-that-an-assembly-forms-properly: {context}]
+ifdef::context[:parent-context-of-testing-that-an-assembly-forms-properly: {context}]
 
 ////
 Base the file name and the ID on the assembly title. For example:
@@ -24,10 +24,10 @@ Add the following attribute before the module ID:
 :_content-type: ASSEMBLY
 
 ifndef::context[]
-[id="assembly_testing-that-an-assembly-forms-properly"]
+[id="testing-that-an-assembly-forms-properly"]
 endif::[]
 ifdef::context[]
-[id="assembly_testing-that-an-assembly-forms-properly_{context}"]
+[id="testing-that-an-assembly-forms-properly_{context}"]
 endif::[]
 = Testing that an assembly forms properly
 ////
@@ -36,7 +36,7 @@ Be sure to include a line break between the title and the :context: variable and
 If the assembly covers a task, start the title with a verb in the gerund form, such as Creating or Configuring.
 ////
 
-:context: assembly_testing-that-an-assembly-forms-properly
+:context: testing-that-an-assembly-forms-properly
 
 ////
 The `context` attribute enables module reuse. Every module ID includes {context}, which ensures that the module has a unique ID so you can include it multiple times in the same guide.
@@ -81,6 +81,6 @@ Optional. Delete if not used.
 ////
 Restore the context to what it was before this assembly.
 ////
-ifdef::parent-context-of-assembly_testing-that-an-assembly-forms-properly[:context: {parent-context-of-assembly_testing-that-an-assembly-forms-properly}]
-ifndef::parent-context-of-assembly_testing-that-an-assembly-forms-properly[:!context:]
+ifdef::parent-context-of-testing-that-an-assembly-forms-properly[:context: {parent-context-of-testing-that-an-assembly-forms-properly}]
+ifndef::parent-context-of-testing-that-an-assembly-forms-properly[:!context:]
 

--- a/tests/generated/con_a-title-that-tests-a-concept.adoc
+++ b/tests/generated/con_a-title-that-tests-a-concept.adoc
@@ -19,7 +19,7 @@ The ID is an anchor that links to the module. Avoid changing it after the module
 The `context` attribute enables module reuse. Every module ID includes {context}, which ensures that the module has a unique ID so you can include it multiple times in the same guide.
 ////
 
-[id="con_a-title-that-tests-a-concept_{context}"]
+[id="a-title-that-tests-a-concept_{context}"]
 = A title that tests a concept
 ////
 In the title of concept modules, include nouns or noun phrases that are used in the body text. This helps readers and search engines find the information quickly. Do not start the title of concept modules with a verb. See also _Wording of headings_ in _The IBM Style Guide_.

--- a/tests/generated/proc_testing-a-procedure.adoc
+++ b/tests/generated/proc_testing-a-procedure.adoc
@@ -13,7 +13,7 @@ Add the following attribute before the module ID:
 ////
 :_content-type: PROCEDURE
 
-[id="proc_testing-a-procedure_{context}"]
+[id="testing-a-procedure_{context}"]
 = Testing a procedure
 ////
 Start the title of a procedure module with a gerund, such as Creating, Installing, or Deploying.

--- a/tests/generated/ref_the-lines-in-a-reference-module.adoc
+++ b/tests/generated/ref_the-lines-in-a-reference-module.adoc
@@ -17,7 +17,7 @@ Add the following attribute before the module ID:
 ////
 :_content-type: REFERENCE
 
-[id="ref_the-lines-in-a-reference-module_{context}"]
+[id="the-lines-in-a-reference-module_{context}"]
 = The lines in a reference module
 ////
 In the title of a reference module, include nouns that are used in the body text. For example, "Keyboard shortcuts for ___" or "Command options for ___." This helps readers and search engines find the information quickly.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -10,7 +10,8 @@ use newdoc::*;
 fn basic_options() -> Options {
     Options {
         comments: true,
-        prefixes: true,
+        file_prefixes: true,
+        anchor_prefixes: false,
         examples: true,
         target_dir: PathBuf::from("."),
         verbosity: Verbosity::Default,
@@ -87,7 +88,8 @@ fn test_snippet_file() {
 fn minimal_options() -> Options {
     Options {
         comments: false,
-        prefixes: false,
+        file_prefixes: true,
+        anchor_prefixes: false,
         examples: false,
         target_dir: PathBuf::from("."),
         verbosity: Verbosity::Default,


### PR DESCRIPTION
Closes #21 