### PR TITLE
Switch to bpaf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,63 +113,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "cc"
-version = "1.0.78"
+name = "bpaf"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "clap"
-version = "4.0.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
+checksum = "31f4c9de9c67618395106c81fb9461290a8910af29aa0188daec29001a1181ae"
 dependencies = [
- "bitflags",
- "clap_derive",
- "clap_lex",
- "is-terminal",
- "once_cell",
- "strsim",
- "termcolor",
+ "bpaf_derive",
+ "owo-colors",
+ "roff",
 ]
 
 [[package]]
-name = "clap_derive"
-version = "4.0.21"
+name = "bpaf_derive"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+checksum = "223f3c9e7034f98c9f315d9945fcc22831b3f03d9f4c42c96a7ab6abd209a195"
 dependencies = [
- "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
 ]
 
 [[package]]
-name = "clap_lex"
-version = "0.3.0"
+name = "cc"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
-name = "clap_mangen"
-version = "0.2.6"
+name = "cfg-if"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904eb24d05ad587557e0f484ddce5c737c30cf81372badb16d13e41c4b8340b1"
-dependencies = [
- "clap",
- "roff",
-]
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "color-eyre"
@@ -175,24 +161,25 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b6515d269224923b26b5febea2ed42b2d5f2ce37284a4dd670fedd6cb8347a"
+checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
  "unicode-width",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "dialoguer"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92e7e37ecef6857fdc0c0c5d42fd5b0938e46590c2183cc92dd310a6d078eb1"
+checksum = "af3c796f3b0b408d9fd581611b47fa850821fcb84aa640b83a3c1a5be2d691f2"
 dependencies = [
  "console",
+ "shell-words",
  "tempfile",
  "zeroize",
 ]
@@ -236,30 +223,24 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.27.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
-
-[[package]]
-name = "heck"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -287,25 +268,19 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.2"
+name = "is_ci"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
-dependencies = [
- "hermit-abi",
- "io-lifetimes",
- "rustix",
- "windows-sys",
-]
+checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
 name = "itoa"
@@ -382,8 +357,7 @@ name = "newdoc"
 version = "2.11.0"
 dependencies = [
  "askama",
- "clap",
- "clap_mangen",
+ "bpaf",
  "color-eyre",
  "dialoguer",
  "log",
@@ -393,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.2"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -421,30 +395,27 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.1"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d864c91689fdc196779b98dba0aceac6118594c2df6ee5d943eb6a8df4d107a"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+dependencies = [
+ "supports-color",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -453,34 +424,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -505,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -519,15 +466,6 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "roff"
@@ -543,16 +481,16 @@ checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustix"
-version = "0.36.6"
+version = "0.36.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -576,6 +514,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "simplelog"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,16 +531,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
+name = "supports-color"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "8ba6faf2ca7ee42fdd458f4347ae0a9bd6bcc445ad7cb57ad82b383f18870d6f"
+dependencies = [
+ "atty",
+ "is_ci",
+]
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -605,16 +553,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -628,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
  "itoa",
  "libc",
@@ -648,18 +595,18 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
 dependencies = [
  "time-core",
 ]
 
 [[package]]
 name = "toml"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
@@ -738,46 +685,70 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+name = "windows-sys"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ edition = "2021"
 rust-version = "1.60"
 documentation = "https://docs.rs/newdoc"
 readme = "README.md"
-repository = "https://github.com/mrksu/newdoc"
+repository = "https://github.com/redhat-documentation/newdoc/"
+homepage = "https://redhat-documentation.github.io/newdoc/"
 categories = ["command-line-utilities", "text-processing"]
 keywords = ["asciidoc", "documentation", "RedHat"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["asciidoc", "documentation", "RedHat"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.0", features = ["cargo", "derive"] }
+bpaf = { version = "0.7", features = ["derive", "bright-color"]}
 regex = "1.7"
 log = "0.4"
 simplelog = "0.12"
@@ -26,5 +26,4 @@ color-eyre = { version = "0.6", default-features = false }
 dialoguer = "0.10"
 
 [build-dependencies]
-clap = { version = "4.0", features = ["derive", "cargo"] }
-clap_mangen = "0.2"
+bpaf = { version = "0.7", features = ["derive", "manpage"]}

--- a/build.rs
+++ b/build.rs
@@ -4,6 +4,7 @@
 //!
 //! The code comes from the sample at <https://rust-cli.github.io/book/in-depth/docs.html>.
 
+/*
 use clap::CommandFactory;
 
 // We're reusing the module just for the Cli struct. Ignore the rest of the code
@@ -27,3 +28,6 @@ fn main() -> std::io::Result<()> {
 
     Ok(())
 }
+*/
+
+fn main() {}

--- a/build.rs
+++ b/build.rs
@@ -1,33 +1,40 @@
-//! This script auto-generates a man page from the clap configuration.
-//! It creates the `newdoc.1` file in the current directory, which is
-//! ignored by git.
-//!
-//! The code comes from the sample at <https://rust-cli.github.io/book/in-depth/docs.html>.
+//! This script auto-generates a man page from the CLI configuration.
 
-/*
-use clap::CommandFactory;
+use bpaf::Section;
 
 // We're reusing the module just for the Cli struct. Ignore the rest of the code
 // and don't report it as "never used" in this build script.
 #[allow(dead_code)]
 #[path = "src/cmd_line.rs"]
 mod cmd_line;
-use cmd_line::Cli;
+
+// Man page metadata
+const CARGO_PKG_NAME: &str = env!("CARGO_PKG_NAME");
+const SECTION: Section = Section::General;
+const DATE: &str = "February 2023";
+const CARGO_PKG_AUTHORS: &str = env!("CARGO_PKG_AUTHORS");
+const CARGO_PKG_REPOSITORY: &str = env!("CARGO_PKG_REPOSITORY");
+const CARGO_PKG_HOMEPAGE: &str = env!("CARGO_PKG_HOMEPAGE");
 
 fn main() -> std::io::Result<()> {
     let out_dir =
         std::path::PathBuf::from(std::env::var_os("OUT_DIR").ok_or(std::io::ErrorKind::NotFound)?);
 
-    let cmd: clap::Command = Cli::command();
+    let parser = cmd_line::cli();
 
-    let man = clap_mangen::Man::new(cmd);
-    let mut buffer: Vec<u8> = Default::default();
-    man.render(&mut buffer)?;
+    let man_page = parser.as_manpage(
+        CARGO_PKG_NAME,
+        SECTION,
+        DATE,
+        CARGO_PKG_AUTHORS,
+        CARGO_PKG_HOMEPAGE,
+        CARGO_PKG_REPOSITORY,
+    );
 
-    std::fs::write(out_dir.join("newdoc.1"), buffer)?;
+    let man_name = format!("{CARGO_PKG_NAME}.1");
+    let man_path = out_dir.join(man_name);
+
+    std::fs::write(man_path, man_page)?;
 
     Ok(())
 }
-*/
-
-fn main() {}

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -27,6 +27,19 @@ use bpaf::Bpaf;
 #[derive(Clone, Debug, Bpaf)]
 #[bpaf(options, version)]
 pub struct Cli {
+    #[bpaf(
+        external,
+        group_help("Generate or validate files:"),
+        guard(at_least_one_file, SOME_FILES)
+    )]
+    pub action: Action,
+
+    #[bpaf(external, group_help("Common options:"))]
+    pub common_options: CommonOptions,
+}
+
+#[derive(Clone, Debug, Bpaf)]
+pub struct CommonOptions {
     /// Generate the file without any comments
     #[bpaf(short('C'), long)]
     pub no_comments: bool,
@@ -44,18 +57,11 @@ pub struct Cli {
     pub anchor_prefixes: bool,
 
     /// Save the generated files in this directory
-    #[bpaf(short('T'), long, argument("DIRECTORY"))]
-    pub target_dir: Option<PathBuf>,
+    #[bpaf(short('T'), long, argument("DIRECTORY"), fallback(".".into()))]
+    pub target_dir: PathBuf,
 
     #[bpaf(external, fallback(Verbosity::Default))]
     pub verbosity: Verbosity,
-
-    #[bpaf(
-        external,
-        group_help("Generate or validate files"),
-        guard(at_least_one_file, SOME_FILES)
-    )]
-    pub action: Action,
 }
 
 #[derive(Clone, Debug, Bpaf)]

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -19,14 +19,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //! # `cmd_line.rs`
 //!
 //! This module defines the command-line arguments and behavior of `newdoc`.
-//! It relies on the `clap` crate.
 
 use std::path::PathBuf;
 
-use clap::{ArgGroup, Parser};
+use bpaf::Bpaf;
 
-#[derive(Parser)]
-#[command(author, version, about, long_about = None, arg_required_else_help(true))]
+#[derive(Clone, Debug, Bpaf)]
+#[bpaf(options, version)]
+/*
 #[command(group(
     ArgGroup::new("required")
                 .args([
@@ -40,66 +40,97 @@ use clap::{ArgGroup, Parser};
                 .required(true)
                 .multiple(true)
 ))]
+*/
 pub struct Cli {
-    /// Create an assembly file
-    #[arg(short, long, value_name = "TITLE")]
-    pub assembly: Option<Vec<String>>,
-
-    /// Create an assembly that includes the other specified modules
-    #[arg(short, long = "include-in", value_name = "TITLE")]
-    pub include_in: Option<String>,
-
-    /// Create a concept module
-    #[arg(short, long, value_name = "TITLE")]
-    pub concept: Option<Vec<String>>,
-
-    /// Create a procedure module
-    #[arg(short, long, value_name = "TITLE")]
-    pub procedure: Option<Vec<String>>,
-
-    /// Create a reference module
-    #[arg(short, long, value_name = "TITLE")]
-    pub reference: Option<Vec<String>>,
-
-    /// Create a snippet file
-    #[arg(short, long, value_name = "TITLE")]
-    pub snippet: Option<Vec<String>>,
-
-    /// Validate (lint) an existing module or assembly file
-    #[arg(short = 'l', long, value_name = "FILE")]
-    pub validate: Option<Vec<PathBuf>>,
-
     /// Generate the file without any comments
-    #[arg(short = 'C', long = "no-comments")]
+    #[bpaf(short('C'), long)]
     pub no_comments: bool,
 
     /// Generate the file without any example, placeholder content
-    #[arg(short = 'E', long = "no-examples", alias = "expert-mode")]
+    #[bpaf(short('E'), long, long("expert-mode"))]
     pub no_examples: bool,
 
     /// Do not use module type prefixes (such as `proc_`) in file names
-    #[arg(short = 'P', long, alias = "no-prefixes")]
+    #[bpaf(short('P'), long, long("no-prefixes"))]
     pub no_file_prefixes: bool,
 
     /// Add use module type prefixes (such as `proc_`) in AsciiDoc anchors
-    #[arg(short = 'A', long)]
+    #[bpaf(short('A'), long)]
     pub anchor_prefixes: bool,
 
     /// Save the generated files in this directory
-    #[arg(short = 'T', long = "target-dir", value_name = "DIRECTORY")]
+    #[bpaf(short('T'), long, argument("DIRECTORY"))]
     pub target_dir: Option<PathBuf>,
 
-    /// Display additional, debug messages
-    #[arg(short, long, conflicts_with = "quiet")]
-    pub verbose: bool,
+    #[bpaf(external, fallback(Verbosity::Default))]
+    pub verbosity: Verbosity,
 
-    /// Hide info-level messages. Display only warnings and errors
-    #[arg(short, long, conflicts_with = "verbose")]
-    pub quiet: bool,
+    #[bpaf(
+        external,
+        group_help("Generate or validate files"),
+        guard(at_least_one_file, SOME_FILES)
+    )]
+    pub action: Action,
 }
+
+#[derive(Clone, Debug, Bpaf)]
+pub struct Action {
+    /// Create an assembly file
+    #[bpaf(short, long, argument("TITLE"), many)]
+    pub assembly: Vec<String>,
+
+    /// Create a concept module
+    #[bpaf(short, long, argument("TITLE"), many)]
+    pub concept: Vec<String>,
+
+    /// Create a procedure module
+    #[bpaf(short, long, argument("TITLE"), many)]
+    pub procedure: Vec<String>,
+
+    /// Create a reference module
+    #[bpaf(short, long, argument("TITLE"), many)]
+    pub reference: Vec<String>,
+
+    /// Create a snippet file
+    #[bpaf(short, long, argument("TITLE"), many)]
+    pub snippet: Vec<String>,
+
+    /// Create an assembly that includes the other specified modules
+    #[bpaf(short, long, argument("TITLE"))]
+    pub include_in: Option<String>,
+    /// Validate (lint) an existing module or assembly file
+    #[bpaf(short('l'), long, argument("FILE"))]
+    pub validate: Vec<PathBuf>,
+}
+
+#[derive(Clone, Copy, Debug, Bpaf)]
+pub enum Verbosity {
+    /// Display additional, debug messages
+    #[bpaf(short, long)]
+    Verbose,
+    /// Hide info-level messages. Display only warnings and errors
+    #[bpaf(short, long)]
+    Quiet,
+    #[bpaf(hide)]
+    Default,
+}
+
+/// Check that the current command generates or validates at least one file.
+fn at_least_one_file(action: &Action) -> bool {
+    !action.assembly.is_empty()
+        || !action.concept.is_empty()
+        || !action.procedure.is_empty()
+        || !action.reference.is_empty()
+        || !action.validate.is_empty()
+        || action.include_in.is_some()
+}
+
+/// The error message if the command does not generate or validate files.
+const SOME_FILES: &str = "Specify at least one file to generate or validate.";
 
 /// Get command-line arguments as the `Cli` struct.
 #[must_use]
 pub fn get_args() -> Cli {
-    Cli::parse()
+    let usage_prefix = "Usage: newdoc {usage}";
+    cli().usage(usage_prefix).run()
 }

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -26,21 +26,6 @@ use bpaf::Bpaf;
 
 #[derive(Clone, Debug, Bpaf)]
 #[bpaf(options, version)]
-/*
-#[command(group(
-    ArgGroup::new("required")
-                .args([
-                    "assembly",
-                    "concept",
-                    "procedure",
-                    "reference",
-                    "snippet",
-                    "validate",
-                ])
-                .required(true)
-                .multiple(true)
-))]
-*/
 pub struct Cli {
     /// Generate the file without any comments
     #[bpaf(short('C'), long)]
@@ -76,33 +61,36 @@ pub struct Cli {
 #[derive(Clone, Debug, Bpaf)]
 pub struct Action {
     /// Create an assembly file
-    #[bpaf(short, long, argument("TITLE"), many)]
+    #[bpaf(short, long, argument("TITLE"))]
     pub assembly: Vec<String>,
 
     /// Create a concept module
-    #[bpaf(short, long, argument("TITLE"), many)]
+    #[bpaf(short, long, argument("TITLE"))]
     pub concept: Vec<String>,
 
     /// Create a procedure module
-    #[bpaf(short, long, argument("TITLE"), many)]
+    #[bpaf(short, long, argument("TITLE"))]
     pub procedure: Vec<String>,
 
     /// Create a reference module
-    #[bpaf(short, long, argument("TITLE"), many)]
+    #[bpaf(short, long, argument("TITLE"))]
     pub reference: Vec<String>,
 
     /// Create a snippet file
-    #[bpaf(short, long, argument("TITLE"), many)]
+    #[bpaf(short, long, argument("TITLE"))]
     pub snippet: Vec<String>,
 
     /// Create an assembly that includes the other specified modules
     #[bpaf(short, long, argument("TITLE"))]
     pub include_in: Option<String>,
+
     /// Validate (lint) an existing module or assembly file
     #[bpaf(short('l'), long, argument("FILE"))]
     pub validate: Vec<PathBuf>,
 }
 
+/// The verbosity level set on the command line.
+/// The default option is invisible as a command-line argument.
 #[derive(Clone, Copy, Debug, Bpaf)]
 pub enum Verbosity {
     /// Display additional, debug messages

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,12 @@ pub fn run(options: &Options, cli: &Cli) -> Result<()> {
 
         populated.write_file(options)?;
     }
+
+    // If the validate option is active, report the deprecation.
+    if !cli.action.validate.is_empty() {
+        log::warn!("The validation feature is deprecated and will be removed in a later version. \
+                   Please switch to the `enki` validation tool: <https://github.com/Levi-Leah/enki/>.");
+    }
     // Validate all file names specified on the command line
     for file in &cli.action.validate {
         validation::validate(file).wrap_err_with(|| eyre!("Failed to validate file {:?}", file))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,13 +72,13 @@ impl Options {
             // Comments and prefixes are enabled (true) by default unless you disable them
             // on the command line. If the no-comments or no-prefixes option is passed,
             // the feature is disabled, so the option is set to false.
-            comments: !cli.no_comments,
-            file_prefixes: !cli.no_file_prefixes,
-            anchor_prefixes: cli.anchor_prefixes,
-            examples: !cli.no_examples,
+            comments: !cli.common_options.no_comments,
+            file_prefixes: !cli.common_options.no_file_prefixes,
+            anchor_prefixes: cli.common_options.anchor_prefixes,
+            examples: !cli.common_options.no_examples,
             // Set the target directory as specified or fall back on the current directory
-            target_dir: cli.target_dir.clone().unwrap_or_else(|| PathBuf::from(".")),
-            verbosity: cli.verbosity,
+            target_dir: cli.common_options.target_dir.clone(),
+            verbosity: cli.common_options.verbosity,
         }
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4,6 +4,7 @@
 
 use std::path::PathBuf;
 
+use cmd_line::Verbosity;
 use newdoc::*;
 
 // These values represent the default newdoc options.


### PR DESCRIPTION
Switch from the clap argument parer to bpaf.

Compared to clap, bpaf has lower requirements on the version of the build toolchain, which helps when building on RHEL. In addition, bpaf is somewhat faster to build and provides an API that is more convenient in certain ways.