### PR TITLE
Add the `[role="_abstract"]` line to generated output

### DIFF
--- a/templates/assembly.adoc
+++ b/templates/assembly.adoc
@@ -47,6 +47,7 @@ The `context` attribute enables module reuse. Every module ID includes {context}
 {%- endif %}
 
 {% if examples -%}
+[role="_abstract"]
 This paragraph is the assembly introduction. It explains what the user will accomplish by working through the modules in the assembly and sets the context for the user story the assembly is based on.
 {%- endif %}
 

--- a/templates/concept.adoc
+++ b/templates/concept.adoc
@@ -30,6 +30,7 @@ In the title of concept modules, include nouns or noun phrases that are used in 
 ////
 
 {% if examples -%}
+[role="_abstract"]
 Write a short introductory paragraph that provides an overview of the module.
 
 The contents of a concept module give the user descriptions and explanations needed to understand and use a product.

--- a/templates/procedure.adoc
+++ b/templates/procedure.adoc
@@ -30,6 +30,7 @@ Start the title of a procedure module with a gerund, such as Creating, Installin
 ////
 
 {% if examples -%}
+[role="_abstract"]
 Write a short introductory paragraph that provides an overview of the module. The introduction should include what the module will help the user do and why it will be beneficial to the user. Include key words that relate to the module to maximize search engine optimization.
 {%- endif %}
 

--- a/templates/reference.adoc
+++ b/templates/reference.adoc
@@ -31,6 +31,7 @@ on.
 ////
 
 {% if examples -%}
+[role="_abstract"]
 Write a short introductory paragraph that provides an overview of the module.
 
 A reference module provides data that users might want to look up, but do not need to remember. It has a very strict structure, often in the form of a list or a table. A well-organized reference module enables users to scan it quickly to find the details they want.

--- a/tests/generated/assembly_testing-that-an-assembly-forms-properly.adoc
+++ b/tests/generated/assembly_testing-that-an-assembly-forms-properly.adoc
@@ -36,6 +36,7 @@ The `context` attribute enables module reuse. Every module ID includes {context}
 ////
 :context: testing-that-an-assembly-forms-properly
 
+[role="_abstract"]
 This paragraph is the assembly introduction. It explains what the user will accomplish by working through the modules in the assembly and sets the context for the user story the assembly is based on.
 
 == Prerequisites

--- a/tests/generated/con_a-title-that-tests-a-concept.adoc
+++ b/tests/generated/con_a-title-that-tests-a-concept.adoc
@@ -23,6 +23,7 @@ Be sure to include a line break between the title and the module introduction.
 In the title of concept modules, include nouns or noun phrases that are used in the body text. This helps readers and search engines find the information quickly. Do not start the title of concept modules with a verb or gerund. See also _Wording of headings_ in _IBM Style_.
 ////
 
+[role="_abstract"]
 Write a short introductory paragraph that provides an overview of the module.
 
 The contents of a concept module give the user descriptions and explanations needed to understand and use a product.

--- a/tests/generated/proc_testing-a-procedure.adoc
+++ b/tests/generated/proc_testing-a-procedure.adoc
@@ -23,6 +23,7 @@ Be sure to include a line break between the title and the module introduction.
 Start the title of a procedure module with a gerund, such as Creating, Installing, or Deploying.
 ////
 
+[role="_abstract"]
 Write a short introductory paragraph that provides an overview of the module. The introduction should include what the module will help the user do and why it will be beneficial to the user. Include key words that relate to the module to maximize search engine optimization.
 
 .Prerequisites

--- a/tests/generated/ref_the-lines-in-a-reference-module.adoc
+++ b/tests/generated/ref_the-lines-in-a-reference-module.adoc
@@ -24,6 +24,7 @@ In the title of a reference module, include nouns that are used in the body text
 on.
 ////
 
+[role="_abstract"]
 Write a short introductory paragraph that provides an overview of the module.
 
 A reference module provides data that users might want to look up, but do not need to remember. It has a very strict structure, often in the form of a list or a table. A well-organized reference module enables users to scan it quickly to find the details they want.


### PR DESCRIPTION
On September 8, 2025, [PR #243](https://github.com/redhat-documentation/modular-docs/pull/243) was merged to the Modular Documentation Project that added the `[role="_abstract"` line to the official templates. While not ideal as the text that follows did not get revised and does not include any guidance on how long this paragraph should be or that it needs to be a single paragraph and not any other block, this pull request ensures that the templates are in sync with the official ones.